### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ESPHome component to monitor and control a APC UPS via RS232
 
 ## Requirements
 
-* [ESPHome 2024.6.0 or higher](https://github.com/esphome/esphome/releases).
+* [ESPHome 2024.12.0 or higher](https://github.com/esphome/esphome/releases).
 * Generic ESP32/ESP8266 board
 
 ## Schematics

--- a/components/apc_ups/__init__.py
+++ b/components/apc_ups/__init__.py
@@ -20,6 +20,7 @@ APC_UPS_COMPONENT_SCHEMA = cv.Schema(
 )
 
 CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 12, 0),
     cv.Schema({cv.GenerateID(): cv.declare_id(ApcUpsComponent)})
     .extend(cv.polling_component_schema("1s"))
     .extend(uart.UART_DEVICE_SCHEMA)

--- a/components/apc_ups/__init__.py
+++ b/components/apc_ups/__init__.py
@@ -23,7 +23,7 @@ CONFIG_SCHEMA = cv.All(
     cv.require_esphome_version(2024, 12, 0),
     cv.Schema({cv.GenerateID(): cv.declare_id(ApcUpsComponent)})
     .extend(cv.polling_component_schema("1s"))
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-apc-ups"
     version: 1.3.0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-apc-ups"
     version: 1.3.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,7 +6,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-apc-protocol.yaml
+++ b/tests/esp8266-apc-protocol.yaml
@@ -7,7 +7,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-apc-rt1000xl-emulator.yaml
+++ b/tests/esp8266-apc-rt1000xl-emulator.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-apc-su420inet-emulator.yaml
+++ b/tests/esp8266-apc-su420inet-emulator.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.