### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/apc_ups/switch/__init__.py
+++ b/components/apc_ups/switch/__init__.py
@@ -32,7 +32,7 @@ ApcUpsSwitch = apc_ups_ns.class_("ApcUpsSwitch", switch.Switch, cg.Component)
 
 APC_UPS_SWITCH_SCHEMA = switch.switch_schema(
     ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
-).extend(cv.COMPONENT_SCHEMA)
+)
 
 CONFIG_SCHEMA = APC_UPS_COMPONENT_SCHEMA.extend(
     {cv.Optional(type): APC_UPS_SWITCH_SCHEMA for type in TYPES}


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from `switch.switch_schema()` calls
- `switch_schema()` includes the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant