### PR TITLE
Add entity_category to binary sensor and switch schemas

### DIFF
--- a/components/apc_ups/switch/__init__.py
+++ b/components/apc_ups/switch/__init__.py
@@ -32,14 +32,33 @@ ApcUpsSwitch = apc_ups_ns.class_("ApcUpsSwitch", switch.Switch, cg.Component)
 
 CONFIG_SCHEMA = APC_UPS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_BEEPER): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG),
-        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
-        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
-        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
-        cv.Optional(CONF_FRONT_PANEL_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
-        cv.Optional(CONF_SELF_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
-        cv.Optional(CONF_START_RUNTIME_CALIBRATION): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
-        cv.Optional(CONF_SIMULATE_POWER_FAILURE): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_BEEPER): switch.switch_schema(
+            ApcUpsSwitch,
+            icon=ICON_POWER,
+            block_inverted=True,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(
+            ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
+        ),
+        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(
+            ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
+        ),
+        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(
+            ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
+        ),
+        cv.Optional(CONF_FRONT_PANEL_TEST): switch.switch_schema(
+            ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
+        ),
+        cv.Optional(CONF_SELF_TEST): switch.switch_schema(
+            ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
+        ),
+        cv.Optional(CONF_START_RUNTIME_CALIBRATION): switch.switch_schema(
+            ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
+        ),
+        cv.Optional(CONF_SIMULATE_POWER_FAILURE): switch.switch_schema(
+            ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
+        ),
     }
 )
 

--- a/components/apc_ups/switch/__init__.py
+++ b/components/apc_ups/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_BEEPER, ICON_POWER
+from esphome.const import CONF_BEEPER, ENTITY_CATEGORY_CONFIG, ICON_POWER
 
 from .. import APC_UPS_COMPONENT_SCHEMA, CONF_APC_UPS_ID, apc_ups_ns
 
@@ -34,8 +34,24 @@ APC_UPS_SWITCH_SCHEMA = switch.switch_schema(
     ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
 ).extend(cv.COMPONENT_SCHEMA)
 
+APC_UPS_CONFIG_SWITCH_SCHEMA = switch.switch_schema(
+    ApcUpsSwitch,
+    icon=ICON_POWER,
+    block_inverted=True,
+    entity_category=ENTITY_CATEGORY_CONFIG,
+).extend(cv.COMPONENT_SCHEMA)
+
 CONFIG_SCHEMA = APC_UPS_COMPONENT_SCHEMA.extend(
-    {cv.Optional(type): APC_UPS_SWITCH_SCHEMA for type in TYPES}
+    {
+        cv.Optional(CONF_BEEPER): APC_UPS_CONFIG_SWITCH_SCHEMA,
+        cv.Optional(CONF_QUICK_TEST): APC_UPS_SWITCH_SCHEMA,
+        cv.Optional(CONF_DEEP_TEST): APC_UPS_SWITCH_SCHEMA,
+        cv.Optional(CONF_TEN_MINUTES_TEST): APC_UPS_SWITCH_SCHEMA,
+        cv.Optional(CONF_FRONT_PANEL_TEST): APC_UPS_SWITCH_SCHEMA,
+        cv.Optional(CONF_SELF_TEST): APC_UPS_SWITCH_SCHEMA,
+        cv.Optional(CONF_START_RUNTIME_CALIBRATION): APC_UPS_SWITCH_SCHEMA,
+        cv.Optional(CONF_SIMULATE_POWER_FAILURE): APC_UPS_SWITCH_SCHEMA,
+    }
 )
 
 

--- a/components/apc_ups/switch/__init__.py
+++ b/components/apc_ups/switch/__init__.py
@@ -18,39 +18,27 @@ CONF_START_RUNTIME_CALIBRATION = "start_runtime_calibration"
 CONF_SIMULATE_POWER_FAILURE = "simulate_power_failure"
 
 TYPES = {
-    CONF_BEEPER: ("Q", "Q"),
-    CONF_QUICK_TEST: ("T", "CT"),
-    CONF_DEEP_TEST: ("TL", "CT"),
-    CONF_TEN_MINUTES_TEST: ("T10", "CT"),
-    CONF_FRONT_PANEL_TEST: ("A", None),
-    CONF_SELF_TEST: ("W", None),
-    CONF_START_RUNTIME_CALIBRATION: ("D", "D"),
-    CONF_SIMULATE_POWER_FAILURE: ("U", None),
+    CONF_BEEPER: ("Q", "Q", ENTITY_CATEGORY_CONFIG),
+    CONF_QUICK_TEST: ("T", "CT", None),
+    CONF_DEEP_TEST: ("TL", "CT", None),
+    CONF_TEN_MINUTES_TEST: ("T10", "CT", None),
+    CONF_FRONT_PANEL_TEST: ("A", None, None),
+    CONF_SELF_TEST: ("W", None, None),
+    CONF_START_RUNTIME_CALIBRATION: ("D", "D", None),
+    CONF_SIMULATE_POWER_FAILURE: ("U", None, None),
 }
 
 ApcUpsSwitch = apc_ups_ns.class_("ApcUpsSwitch", switch.Switch, cg.Component)
 
-APC_UPS_SWITCH_SCHEMA = switch.switch_schema(
-    ApcUpsSwitch, icon=ICON_POWER, block_inverted=True
-).extend(cv.COMPONENT_SCHEMA)
-
-APC_UPS_CONFIG_SWITCH_SCHEMA = switch.switch_schema(
-    ApcUpsSwitch,
-    icon=ICON_POWER,
-    block_inverted=True,
-    entity_category=ENTITY_CATEGORY_CONFIG,
-).extend(cv.COMPONENT_SCHEMA)
-
 CONFIG_SCHEMA = APC_UPS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_BEEPER): APC_UPS_CONFIG_SWITCH_SCHEMA,
-        cv.Optional(CONF_QUICK_TEST): APC_UPS_SWITCH_SCHEMA,
-        cv.Optional(CONF_DEEP_TEST): APC_UPS_SWITCH_SCHEMA,
-        cv.Optional(CONF_TEN_MINUTES_TEST): APC_UPS_SWITCH_SCHEMA,
-        cv.Optional(CONF_FRONT_PANEL_TEST): APC_UPS_SWITCH_SCHEMA,
-        cv.Optional(CONF_SELF_TEST): APC_UPS_SWITCH_SCHEMA,
-        cv.Optional(CONF_START_RUNTIME_CALIBRATION): APC_UPS_SWITCH_SCHEMA,
-        cv.Optional(CONF_SIMULATE_POWER_FAILURE): APC_UPS_SWITCH_SCHEMA,
+        cv.Optional(type): switch.switch_schema(
+            ApcUpsSwitch,
+            icon=ICON_POWER,
+            block_inverted=True,
+            **({} if cat is None else {"entity_category": cat}),
+        ).extend(cv.COMPONENT_SCHEMA)
+        for type, (_, _, cat) in TYPES.items()
     }
 )
 
@@ -58,7 +46,7 @@ CONFIG_SCHEMA = APC_UPS_COMPONENT_SCHEMA.extend(
 async def to_code(config):
     paren = await cg.get_variable(config[CONF_APC_UPS_ID])
 
-    for type, (on, off) in TYPES.items():
+    for type, (on, off, _) in TYPES.items():
         if type in config:
             conf = config[type]
             var = await switch.new_switch(conf)

--- a/components/apc_ups/switch/__init__.py
+++ b/components/apc_ups/switch/__init__.py
@@ -18,35 +18,40 @@ CONF_START_RUNTIME_CALIBRATION = "start_runtime_calibration"
 CONF_SIMULATE_POWER_FAILURE = "simulate_power_failure"
 
 TYPES = {
-    CONF_BEEPER: ("Q", "Q", ENTITY_CATEGORY_CONFIG),
-    CONF_QUICK_TEST: ("T", "CT", None),
-    CONF_DEEP_TEST: ("TL", "CT", None),
-    CONF_TEN_MINUTES_TEST: ("T10", "CT", None),
-    CONF_FRONT_PANEL_TEST: ("A", None, None),
-    CONF_SELF_TEST: ("W", None, None),
-    CONF_START_RUNTIME_CALIBRATION: ("D", "D", None),
-    CONF_SIMULATE_POWER_FAILURE: ("U", None, None),
+    CONF_BEEPER: ("Q", "Q"),
+    CONF_QUICK_TEST: ("T", "CT"),
+    CONF_DEEP_TEST: ("TL", "CT"),
+    CONF_TEN_MINUTES_TEST: ("T10", "CT"),
+    CONF_FRONT_PANEL_TEST: ("A", None),
+    CONF_SELF_TEST: ("W", None),
+    CONF_START_RUNTIME_CALIBRATION: ("D", "D"),
+    CONF_SIMULATE_POWER_FAILURE: ("U", None),
 }
 
 ApcUpsSwitch = apc_ups_ns.class_("ApcUpsSwitch", switch.Switch, cg.Component)
 
+SWITCH_SCHEMAS = {
+    CONF_BEEPER: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG).extend(cv.COMPONENT_SCHEMA),
+    CONF_QUICK_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    CONF_DEEP_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    CONF_TEN_MINUTES_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    CONF_FRONT_PANEL_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    CONF_SELF_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    CONF_START_RUNTIME_CALIBRATION: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    CONF_SIMULATE_POWER_FAILURE: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+}
+
+assert set(TYPES) == set(SWITCH_SCHEMAS), "TYPES and SWITCH_SCHEMAS are out of sync"
+
 CONFIG_SCHEMA = APC_UPS_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(type): switch.switch_schema(
-            ApcUpsSwitch,
-            icon=ICON_POWER,
-            block_inverted=True,
-            **({} if cat is None else {"entity_category": cat}),
-        ).extend(cv.COMPONENT_SCHEMA)
-        for type, (_, _, cat) in TYPES.items()
-    }
+    {cv.Optional(type): SWITCH_SCHEMAS[type] for type in TYPES}
 )
 
 
 async def to_code(config):
     paren = await cg.get_variable(config[CONF_APC_UPS_ID])
 
-    for type, (on, off, _) in TYPES.items():
+    for type, (on, off) in TYPES.items():
         if type in config:
             conf = config[type]
             var = await switch.new_switch(conf)

--- a/components/apc_ups/switch/__init__.py
+++ b/components/apc_ups/switch/__init__.py
@@ -30,21 +30,17 @@ TYPES = {
 
 ApcUpsSwitch = apc_ups_ns.class_("ApcUpsSwitch", switch.Switch, cg.Component)
 
-SWITCH_SCHEMAS = {
-    CONF_BEEPER: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG).extend(cv.COMPONENT_SCHEMA),
-    CONF_QUICK_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-    CONF_DEEP_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-    CONF_TEN_MINUTES_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-    CONF_FRONT_PANEL_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-    CONF_SELF_TEST: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-    CONF_START_RUNTIME_CALIBRATION: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-    CONF_SIMULATE_POWER_FAILURE: switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-}
-
-assert set(TYPES) == set(SWITCH_SCHEMAS), "TYPES and SWITCH_SCHEMAS are out of sync"
-
 CONFIG_SCHEMA = APC_UPS_COMPONENT_SCHEMA.extend(
-    {cv.Optional(type): SWITCH_SCHEMAS[type] for type in TYPES}
+    {
+        cv.Optional(CONF_BEEPER): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_FRONT_PANEL_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_SELF_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_START_RUNTIME_CALIBRATION): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_SIMULATE_POWER_FAILURE): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+    }
 )
 
 

--- a/components/apc_ups/switch/__init__.py
+++ b/components/apc_ups/switch/__init__.py
@@ -32,14 +32,14 @@ ApcUpsSwitch = apc_ups_ns.class_("ApcUpsSwitch", switch.Switch, cg.Component)
 
 CONFIG_SCHEMA = APC_UPS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_BEEPER): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_FRONT_PANEL_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_SELF_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_START_RUNTIME_CALIBRATION): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_SIMULATE_POWER_FAILURE): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_BEEPER): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True, entity_category=ENTITY_CATEGORY_CONFIG),
+        cv.Optional(CONF_QUICK_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_DEEP_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_TEN_MINUTES_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_FRONT_PANEL_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_SELF_TEST): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_START_RUNTIME_CALIBRATION): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
+        cv.Optional(CONF_SIMULATE_POWER_FAILURE): switch.switch_schema(ApcUpsSwitch, icon=ICON_POWER, block_inverted=True),
     }
 )
 


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Add entity_category=ENTITY_CATEGORY_CONFIG to configuration switches (bluetooth, buzzer, display). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.