### PR TITLE
Fix bitmask sensors: remove state_class, set device_class=None, add diagnostic entity_category

### DIFF
--- a/components/apc_ups/sensor/__init__.py
+++ b/components/apc_ups/sensor/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_VOLTAGE,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_CURRENT_AC,
     ICON_TIMELAPSE,
     STATE_CLASS_MEASUREMENT,
@@ -109,8 +110,8 @@ TYPES = {
         unit_of_measurement=UNIT_EMPTY,
         icon=ICON_OPERATION_STATUS_BITMASK,
         accuracy_decimals=0,
-        device_class=DEVICE_CLASS_EMPTY,
-        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=None,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     cv.Optional(CONF_STATE_OF_CHARGE): sensor.sensor_schema(
         unit_of_measurement=UNIT_PERCENT,


### PR DESCRIPTION
## Changes

Bitmask sensors represent raw status/flag values, not physical measurements. This fix aligns them with ESPHome best practices:

- Remove `state_class` (bitmasks are not measurements)
- Set `device_class=None` (no meaningful device class applies)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC`