### PR TITLE
Fix bitmask sensor

### DIFF
--- a/components/apc_ups/sensor/__init__.py
+++ b/components/apc_ups/sensor/__init__.py
@@ -110,7 +110,7 @@ TYPES = {
         unit_of_measurement=UNIT_EMPTY,
         icon=ICON_OPERATION_STATUS_BITMASK,
         accuracy_decimals=0,
-        device_class=None,
+        device_class=DEVICE_CLASS_EMPTY,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     cv.Optional(CONF_STATE_OF_CHARGE): sensor.sensor_schema(


### PR DESCRIPTION
`device_class=None` is not a valid value in ESPHome's sensor schema and causes a validation error:

```
string value is None.
Error: Process completed with exit code 2.
```

Replace with `DEVICE_CLASS_EMPTY` which is the correct constant for sensors without a device class.