### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/apc_ups/binary_sensor/__init__.py
+++ b/components/apc_ups/binary_sensor/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from .. import APC_UPS_COMPONENT_SCHEMA, CONF_APC_UPS_ID
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 
 CONF_FAULTS_PRESENT = "faults_present"
 

--- a/components/apc_ups/sensor/__init__.py
+++ b/components/apc_ups/sensor/__init__.py
@@ -24,6 +24,7 @@ from esphome.const import (
 from .. import APC_UPS_COMPONENT_SCHEMA, CONF_APC_UPS_ID
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 
 # CONF_BATTERY_VOLTAGE = "battery_voltage"
 CONF_GRID_FREQUENCY = "grid_frequency"

--- a/components/apc_ups/switch/__init__.py
+++ b/components/apc_ups/switch/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_BEEPER, ENTITY_CATEGORY_CONFIG, ICON_POWER
 from .. import APC_UPS_COMPONENT_SCHEMA, CONF_APC_UPS_ID, apc_ups_ns
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 
 # CONF_BEEPER = "beeper"
 CONF_QUICK_TEST = "quick_test"

--- a/components/apc_ups/text_sensor/__init__.py
+++ b/components/apc_ups/text_sensor/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from .. import APC_UPS_COMPONENT_SCHEMA, CONF_APC_UPS_ID
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 
 CONF_CAUSE_OF_LAST_TRANSFER = "cause_of_last_transfer"
 CONF_PROTOCOL_INFO = "protocol_info"


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `sensor/__init__.py`, `binary_sensor/__init__.py`, `text_sensor/__init__.py`, and `switch/__init__.py` for consistency with other ESPHome components.