### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/apc_ups/apc_ups.cpp
+++ b/components/apc_ups/apc_ups.cpp
@@ -1,8 +1,7 @@
 #include "apc_ups.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace apc_ups {
+namespace esphome::apc_ups {
 
 static const char *const TAG = "apc_ups";
 
@@ -638,5 +637,4 @@ void ApcUps::publish_state_(text_sensor::TextSensor *text_sensor, const std::str
   text_sensor->publish_state(state);
 }
 
-}  // namespace apc_ups
-}  // namespace esphome
+}  // namespace esphome::apc_ups

--- a/components/apc_ups/apc_ups.h
+++ b/components/apc_ups/apc_ups.h
@@ -8,8 +8,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace apc_ups {
+namespace esphome::apc_ups {
 
 enum ENUMPollingCommand {
   POLLING_Y = 0,         // Enable smart mode
@@ -192,5 +191,4 @@ class ApcUps : public uart::UARTDevice, public PollingComponent {
   PollingCommand used_polling_commands_[41];
 };
 
-}  // namespace apc_ups
-}  // namespace esphome
+}  // namespace esphome::apc_ups

--- a/components/apc_ups/switch/apc_ups_switch.cpp
+++ b/components/apc_ups/switch/apc_ups_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace apc_ups {
+namespace esphome::apc_ups {
 
 static const char *const TAG = "apc_ups.switch";
 
@@ -21,5 +20,4 @@ void ApcUpsSwitch::write_state(bool state) {
   this->publish_state(state);
 }
 
-}  // namespace apc_ups
-}  // namespace esphome
+}  // namespace esphome::apc_ups

--- a/components/apc_ups/switch/apc_ups_switch.h
+++ b/components/apc_ups/switch/apc_ups_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace apc_ups {
+namespace esphome::apc_ups {
 class ApcUps;
 class ApcUpsSwitch : public switch_::Switch, public Component {
  public:
@@ -21,5 +20,4 @@ class ApcUpsSwitch : public switch_::Switch, public Component {
   ApcUps *parent_;
 };
 
-}  // namespace apc_ups
-}  // namespace esphome
+}  // namespace esphome::apc_ups


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.