### PR TITLE
Add status text sensor

### DIFF
--- a/components/apc_ups/apc_ups.cpp
+++ b/components/apc_ups/apc_ups.cpp
@@ -128,12 +128,13 @@ void ApcUps::loop() {
         this->publish_state_(this->output_overloaded_, check_bit_(value_status_bitmask_, 32));
         this->publish_state_(this->battery_low_, check_bit_(value_status_bitmask_, 64));
         this->publish_state_(this->replace_battery_, check_bit_(value_status_bitmask_, 128));
-        if (check_bit_(value_status_bitmask_, 8))
+        if (check_bit_(value_status_bitmask_, 8)) {
           this->publish_state_(this->status_, "Online");
-        else if (check_bit_(value_status_bitmask_, 16))
+        } else if (check_bit_(value_status_bitmask_, 16)) {
           this->publish_state_(this->status_, "On Battery");
-        else
+        } else {
           this->publish_state_(this->status_, "Unknown");
+        }
         break;
       case POLLING_X:
         this->publish_state_(this->self_test_results_, value_self_test_results_);
@@ -462,8 +463,9 @@ void ApcUps::loop() {
     if (millis() - this->command_start_millis_ > esphome::apc_ups::ApcUps::COMMAND_TIMEOUT) {
       // command timeout
       ESP_LOGD(TAG, "timeout command to poll: %s", this->used_polling_commands_[this->last_polling_command_].command);
-      if (this->used_polling_commands_[this->last_polling_command_].identifier == POLLING_Q)
+      if (this->used_polling_commands_[this->last_polling_command_].identifier == POLLING_Q) {
         this->publish_state_(this->status_, "Unknown");
+      }
       this->state_ = STATE_IDLE;
     }
   }

--- a/components/apc_ups/apc_ups.cpp
+++ b/components/apc_ups/apc_ups.cpp
@@ -128,6 +128,12 @@ void ApcUps::loop() {
         this->publish_state_(this->output_overloaded_, check_bit_(value_status_bitmask_, 32));
         this->publish_state_(this->battery_low_, check_bit_(value_status_bitmask_, 64));
         this->publish_state_(this->replace_battery_, check_bit_(value_status_bitmask_, 128));
+        if (check_bit_(value_status_bitmask_, 8))
+          this->publish_state_(this->status_, "Online");
+        else if (check_bit_(value_status_bitmask_, 16))
+          this->publish_state_(this->status_, "On Battery");
+        else
+          this->publish_state_(this->status_, "Unknown");
         break;
       case POLLING_X:
         this->publish_state_(this->self_test_results_, value_self_test_results_);
@@ -456,6 +462,8 @@ void ApcUps::loop() {
     if (millis() - this->command_start_millis_ > esphome::apc_ups::ApcUps::COMMAND_TIMEOUT) {
       // command timeout
       ESP_LOGD(TAG, "timeout command to poll: %s", this->used_polling_commands_[this->last_polling_command_].command);
+      if (this->used_polling_commands_[this->last_polling_command_].identifier == POLLING_Q)
+        this->publish_state_(this->status_, "Unknown");
       this->state_ = STATE_IDLE;
     }
   }
@@ -566,6 +574,7 @@ void ApcUps::dump_config() {
   LOG_BINARY_SENSOR("", "Battery Low", this->battery_low_);
   LOG_BINARY_SENSOR("", "Replace Battery", this->replace_battery_);
 
+  LOG_TEXT_SENSOR("", "Status", this->status_);
   LOG_TEXT_SENSOR("", "Cause Of Last Transfer", this->cause_of_last_transfer_);
   LOG_TEXT_SENSOR("", "Old Firmware Version", this->old_firmware_version_);
   LOG_TEXT_SENSOR("", "Self Test Results", this->self_test_results_);

--- a/components/apc_ups/apc_ups.h
+++ b/components/apc_ups/apc_ups.h
@@ -115,6 +115,14 @@ class ApcUps : public uart::UARTDevice, public PollingComponent {
   APC_UPS_BINARY_SENSOR(smart_boost, Q, Q)
   APC_UPS_BINARY_SENSOR(on_line, Q, Q)
   APC_UPS_BINARY_SENSOR(on_battery, Q, Q)
+ protected:
+  text_sensor::TextSensor *status_{};
+
+ public:
+  void set_status(text_sensor::TextSensor *s) {
+    this->status_ = s;
+    this->add_polling_command_("Q", POLLING_Q);
+  }
   APC_UPS_BINARY_SENSOR(output_overloaded, Q, Q)
   APC_UPS_BINARY_SENSOR(battery_low, Q, Q)
   APC_UPS_BINARY_SENSOR(replace_battery, Q, Q)

--- a/components/apc_ups/text_sensor/__init__.py
+++ b/components/apc_ups/text_sensor/__init__.py
@@ -1,13 +1,13 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import CONF_STATUS
 
 from .. import APC_UPS_COMPONENT_SCHEMA, CONF_APC_UPS_ID
 
 DEPENDENCIES = ["uart"]
 CODEOWNERS = ["@syssi"]
 
-CONF_STATUS = "status"
 CONF_CAUSE_OF_LAST_TRANSFER = "cause_of_last_transfer"
 CONF_PROTOCOL_INFO = "protocol_info"
 CONF_FIRMWARE_REVISION = "firmware_revision"

--- a/components/apc_ups/text_sensor/__init__.py
+++ b/components/apc_ups/text_sensor/__init__.py
@@ -7,6 +7,7 @@ from .. import APC_UPS_COMPONENT_SCHEMA, CONF_APC_UPS_ID
 DEPENDENCIES = ["uart"]
 CODEOWNERS = ["@syssi"]
 
+CONF_STATUS = "status"
 CONF_CAUSE_OF_LAST_TRANSFER = "cause_of_last_transfer"
 CONF_PROTOCOL_INFO = "protocol_info"
 CONF_FIRMWARE_REVISION = "firmware_revision"
@@ -23,6 +24,7 @@ CONF_LINE_QUALITY = "line_quality"
 CONF_MODEL_NAME = "model_name"
 
 TYPES = [
+    CONF_STATUS,
     CONF_CAUSE_OF_LAST_TRANSFER,
     CONF_PROTOCOL_INFO,
     CONF_FIRMWARE_REVISION,

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -127,6 +127,8 @@ sensor:
 text_sensor:
   - platform: apc_ups
     apc_ups_id: ups0
+    status:
+      name: "status"
     cause_of_last_transfer:
       name: "cause of last transfer"
     # Could cause a connection reset of the Home Assistant API connection

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -125,6 +125,8 @@ sensor:
 text_sensor:
   - platform: apc_ups
     apc_ups_id: ups0
+    status:
+      name: "status"
     cause_of_last_transfer:
       name: "cause of last transfer"
     # Could cause a connection reset of the Home Assistant API connection

--- a/tests/components/apc_ups/apc_ups_test.cpp
+++ b/tests/components/apc_ups/apc_ups_test.cpp
@@ -32,6 +32,7 @@ class ApcUpsDecodeTest : public ::testing::Test {
   binary_sensor::BinarySensor on_line_;
   binary_sensor::BinarySensor on_battery_;
   binary_sensor::BinarySensor replace_battery_;
+  text_sensor::TextSensor status_;
   text_sensor::TextSensor firmware_revision_;
   text_sensor::TextSensor local_identifier_;
   text_sensor::TextSensor manufacture_date_;
@@ -58,6 +59,7 @@ class ApcUpsDecodeTest : public ::testing::Test {
     ups_.set_on_line(&on_line_);
     ups_.set_on_battery(&on_battery_);
     ups_.set_replace_battery(&replace_battery_);
+    ups_.set_status(&status_);
     ups_.set_firmware_revision(&firmware_revision_);
     ups_.set_local_identifier(&local_identifier_);
     ups_.set_manufacture_date(&manufacture_date_);
@@ -112,6 +114,16 @@ TEST_F(ApcUpsDecodeTest, StatusBitmaskOnLine) {
 TEST_F(ApcUpsDecodeTest, StatusBitmaskOnBatteryFalse) {
   ups_.decode_and_publish(POLLING_Q, "8F\r");
   EXPECT_FALSE(on_battery_.state);
+}
+
+TEST_F(ApcUpsDecodeTest, StatusTextOnline) {
+  ups_.decode_and_publish(POLLING_Q, "08\r");
+  EXPECT_EQ(status_.state, "Online");
+}
+
+TEST_F(ApcUpsDecodeTest, StatusTextOnBattery) {
+  ups_.decode_and_publish(POLLING_Q, "10\r");
+  EXPECT_EQ(status_.state, "On Battery");
 }
 
 TEST_F(ApcUpsDecodeTest, StatusBitmaskReplaceBattery) {

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -37,9 +37,10 @@ class TestSensorTypes:
 
 class TestTextSensorTypes:
     def test_types_list_completeness(self):
+        assert text_sensor.CONF_STATUS in text_sensor.TYPES
         assert text_sensor.CONF_MODEL_NAME in text_sensor.TYPES
         assert text_sensor.CONF_SERIAL_NUMBER in text_sensor.TYPES
-        assert len(text_sensor.TYPES) == 14
+        assert len(text_sensor.TYPES) == 15
 
 
 class TestSwitchTypes:


### PR DESCRIPTION
## Summary

- Adds a `status` text sensor to the `text_sensor` platform that derives a human-readable state from the `Q` status bitmask
- Publishes `"Online"` (bit 8 set), `"On Battery"` (bit 16 set), or `"Unknown"` (poll timeout / UPS not responding)
- Registers `POLLING_Q` automatically so the sensor works independently of the `on_line`/`on_battery` binary sensors

## Test plan

- [ ] C++ unit tests: `StatusTextOnline` (`0x08` → `"Online"`), `StatusTextOnBattery` (`0x10` → `"On Battery"`)
- [ ] Schema test: `CONF_STATUS` in `TYPES`, count updated to 15
- [ ] Example YAMLs compile with `status` entry in the `text_sensor` block