### PR TITLE
Fix API connection reset caused by non-printable chars in text sensor values

### DIFF
--- a/components/apc_ups/apc_ups.cpp
+++ b/components/apc_ups/apc_ups.cpp
@@ -212,6 +212,9 @@ void ApcUps::loop() {
   if (this->state_ == STATE_POLL_CHECKED) {
     char *tmp = reinterpret_cast<char *>(this->read_buffer_);
     tmp[strcspn(tmp, "\r\n")] = '\0';
+    for (char *p = tmp; *p; ++p)
+      if ((uint8_t) *p < 0x20 || (uint8_t) *p > 0x7E)
+        *p = '?';
     switch (this->used_polling_commands_[this->last_polling_command_].identifier) {
       case POLLING_Y:
         ESP_LOGD(TAG, "Decode Y");
@@ -239,7 +242,7 @@ void ApcUps::loop() {
       case POLLING_G:
         ESP_LOGD(TAG, "Decode G");
         // "G\r\n"
-        this->value_cause_of_last_transfer_ = this->read_buffer_[0];
+        this->value_cause_of_last_transfer_ = tmp;
         this->state_ = STATE_POLL_DECODED;
         break;
       case POLLING_L:

--- a/components/apc_ups/apc_ups.cpp
+++ b/components/apc_ups/apc_ups.cpp
@@ -212,9 +212,10 @@ void ApcUps::loop() {
   if (this->state_ == STATE_POLL_CHECKED) {
     char *tmp = reinterpret_cast<char *>(this->read_buffer_);
     tmp[strcspn(tmp, "\r\n")] = '\0';
-    for (char *p = tmp; *p; ++p)
+    for (char *p = tmp; *p; ++p) {
       if ((uint8_t) *p < 0x20 || (uint8_t) *p > 0x7E)
         *p = '?';
+    }
     switch (this->used_polling_commands_[this->last_polling_command_].identifier) {
       case POLLING_Y:
         ESP_LOGD(TAG, "Decode Y");

--- a/components/apc_ups/apc_ups.cpp
+++ b/components/apc_ups/apc_ups.cpp
@@ -529,7 +529,7 @@ void ApcUps::queue_command_(const char *command, uint8_t length) {
     uint8_t testposition = (next_position + i) % COMMAND_QUEUE_LENGTH;
     if (command_queue_[testposition].empty()) {
       command_queue_[testposition] = command;
-      ESP_LOGD(TAG, "Command queued successfully: %s with length %u at position %d", command,
+      ESP_LOGD(TAG, "Command queued successfully: %s with length %zu at position %d", command,
                command_queue_[testposition].length(), testposition);
       return;
     }

--- a/tests/components/apc_ups/apc_ups_test.cpp
+++ b/tests/components/apc_ups/apc_ups_test.cpp
@@ -186,8 +186,8 @@ TEST_F(ApcUpsDecodeTest, ManufactureDate) {
 
 TEST_F(ApcUpsDecodeTest, StringSanitizesAllBytes) {
   for (int b = 0x00; b <= 0xFF; b++) {
-    if (b == 0x0D)
-      continue;  // \r is the response terminator, not part of the value
+    if (b == 0x0D || b == 0x0A)
+      continue;  // \r and \n are response terminators, stripped by strcspn before sanitization
     uint8_t buf[2] = {(uint8_t) b, 0x0D};
     ups_.decode_and_publish_bytes(POLLING_LOWER_A, buf, sizeof(buf));
     std::ostringstream ctx;

--- a/tests/components/apc_ups/apc_ups_test.cpp
+++ b/tests/components/apc_ups/apc_ups_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <sstream>
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
@@ -33,6 +34,7 @@ class ApcUpsDecodeTest : public ::testing::Test {
   binary_sensor::BinarySensor on_battery_;
   binary_sensor::BinarySensor replace_battery_;
   text_sensor::TextSensor status_;
+  text_sensor::TextSensor protocol_info_;
   text_sensor::TextSensor firmware_revision_;
   text_sensor::TextSensor local_identifier_;
   text_sensor::TextSensor manufacture_date_;
@@ -60,6 +62,7 @@ class ApcUpsDecodeTest : public ::testing::Test {
     ups_.set_on_battery(&on_battery_);
     ups_.set_replace_battery(&replace_battery_);
     ups_.set_status(&status_);
+    ups_.set_protocol_info(&protocol_info_);
     ups_.set_firmware_revision(&firmware_revision_);
     ups_.set_local_identifier(&local_identifier_);
     ups_.set_manufacture_date(&manufacture_date_);
@@ -179,6 +182,24 @@ TEST_F(ApcUpsDecodeTest, LocalIdentifier) {
 TEST_F(ApcUpsDecodeTest, ManufactureDate) {
   ups_.decode_and_publish(POLLING_LOWER_M, "11/17/98\r");
   EXPECT_EQ(manufacture_date_.state.substr(0, 8), "11/17/98");
+}
+
+TEST_F(ApcUpsDecodeTest, StringSanitizesAllBytes) {
+  for (int b = 0x00; b <= 0xFF; b++) {
+    if (b == 0x0D)
+      continue;  // \r is the response terminator, not part of the value
+    uint8_t buf[2] = {(uint8_t) b, 0x0D};
+    ups_.decode_and_publish_bytes(POLLING_LOWER_A, buf, sizeof(buf));
+    std::ostringstream ctx;
+    ctx << "byte 0x" << std::hex << b;
+    if (b == 0x00) {
+      EXPECT_EQ(protocol_info_.state, "") << ctx.str() << " (null) should yield empty string";
+    } else if (b >= 0x20 && b <= 0x7E) {
+      EXPECT_EQ(protocol_info_.state, std::string(1, (char) b)) << ctx.str() << " (printable) should pass unchanged";
+    } else {
+      EXPECT_EQ(protocol_info_.state, "?") << ctx.str() << " (non-printable) should become '?'";
+    }
+  }
 }
 
 }  // namespace esphome::apc_ups::testing

--- a/tests/components/apc_ups/apc_ups_test.cpp
+++ b/tests/components/apc_ups/apc_ups_test.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <sstream>
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
@@ -190,14 +189,12 @@ TEST_F(ApcUpsDecodeTest, StringSanitizesAllBytes) {
       continue;  // \r and \n are response terminators, stripped by strcspn before sanitization
     uint8_t buf[2] = {(uint8_t) b, 0x0D};
     ups_.decode_and_publish_bytes(POLLING_LOWER_A, buf, sizeof(buf));
-    std::ostringstream ctx;
-    ctx << "byte 0x" << std::hex << b;
     if (b == 0x00) {
-      EXPECT_EQ(protocol_info_.state, "") << ctx.str() << " (null) should yield empty string";
+      EXPECT_EQ(protocol_info_.state, "") << "byte " << b << " (null) should yield empty string";
     } else if (b >= 0x20 && b <= 0x7E) {
-      EXPECT_EQ(protocol_info_.state, std::string(1, (char) b)) << ctx.str() << " (printable) should pass unchanged";
+      EXPECT_EQ(protocol_info_.state, std::string(1, (char) b)) << "byte " << b << " (printable) should pass unchanged";
     } else {
-      EXPECT_EQ(protocol_info_.state, "?") << ctx.str() << " (non-printable) should become '?'";
+      EXPECT_EQ(protocol_info_.state, "?") << "byte " << b << " (non-printable) should become '?'";
     }
   }
 }

--- a/tests/components/apc_ups/common.h
+++ b/tests/components/apc_ups/common.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <cstring>
 #include <string>
 #include "esphome/components/apc_ups/apc_ups.h"
@@ -18,6 +19,21 @@ class TestableApcUps : public ApcUps {
     state_ = STATE_POLL_CHECKED;
     loop();  // decode: STATE_POLL_CHECKED -> STATE_POLL_DECODED
     loop();  // publish: STATE_POLL_DECODED -> STATE_IDLE
+  }
+
+  void decode_and_publish_bytes(ENUMPollingCommand cmd, const uint8_t *data, size_t len) {
+    for (size_t i = 0; i < 41; i++) {
+      if (used_polling_commands_[i].length > 0 && used_polling_commands_[i].identifier == cmd) {
+        last_polling_command_ = i;
+        break;
+      }
+    }
+    size_t n = std::min(len, APC_UPS_READ_BUFFER_LENGTH - 1);
+    memcpy(read_buffer_, data, n);
+    read_buffer_[n] = 0;
+    state_ = STATE_POLL_CHECKED;
+    loop();
+    loop();
   }
 };
 


### PR DESCRIPTION
## Summary

- Replace all bytes outside printable ASCII range (0x20–0x7E) with `?` before assigning UPS responses to text sensors — applies globally to every response, not just `protocol_info`
- Fix `cause_of_last_transfer_` using the raw buffer byte directly instead of the sanitized `tmp` pointer, which could pass a `\0` byte as a 1-char string to the API
- Add `decode_and_publish_bytes()` test helper (uses `memcpy` instead of `strncpy` to allow raw bytes including `\0`) and a test that iterates all 256 byte values, verifying non-printable chars become `?` and printable chars pass through unchanged

Fixes #1